### PR TITLE
Return non-nil bindErrs from control function

### DIFF
--- a/icmp_linux.go
+++ b/icmp_linux.go
@@ -60,12 +60,13 @@ func ListenPacket(network, address, sourceInterface string) (*PacketConn, error)
 
 	lc := net.ListenConfig{
 		Control: func(network, address string, c syscall.RawConn) (err error) {
+			var bindErr error
 			ctrlErr := c.Control(func(fd uintptr) {
-				bindErr := bindInterface(int(fd), sourceInterface)
-				if bindErr != nil {
-					return
-				}
+				bindErr = bindInterface(int(fd), sourceInterface)
 			})
+			if bindErr != nil {
+				return bindErr
+			}
 			return ctrlErr
 		},
 	}


### PR DESCRIPTION
Currently, errors returned by `bindInterface` are silently ignored. This can result in cases where a pinger is successfully created, even though it really shouldn't be. For example, setting `Pinger.SourceInterface` to a nonexistent interface results in a Pinger being created "successfully," even though it will never be able to actually send or receive traffic.

This PR modifies the `net.ListenConfig` control function to capture and return non-nil errs from `bindInterface`. In the nonexistent interface example from above, we'll now bubble up the `ENODEV` (no such device) error that's returned from `setsockopt`, and `Pinger.Run` will immediately return an error instead of appearing to start successfully.