### PR TITLE
Wrap sequence number after 65535

### DIFF
--- a/ping.go
+++ b/ping.go
@@ -49,7 +49,6 @@
 // it calls the OnFinish callback.
 //
 // For a full ping example, see "cmd/ping/ping.go".
-//
 package ping
 
 import (
@@ -680,6 +679,9 @@ func (p *Pinger) sendICMP(conn *PacketConn) error {
 		p.awaitingSequences[p.sequence] = struct{}{}
 		p.PacketsSent++
 		p.sequence++
+		if p.sequence > 65535 {
+			p.sequence = 0
+		}
 		break
 	}
 


### PR DESCRIPTION
This PR fixes a bug where the Pinger stops behaving correctly after sending 65535 pings. The behavior that I observed was that  `PacketsRecv` got stuck at 65536 while `PacketsSent` continued to increment as expected. Wireshark showed that pings were still being sent and received, with the sequence number wrapping back around to 0 as expected.

The problem is that `p.awaitingSequences` is an `int`, whereas a sequence number on the wire is an unsigned 16-bit integer. Internally, `p.sequence` is allowed to exceed the maximum allowed value of 65535, even though the sequences sent on the wire do get wrapped properly (maybe by the kernel; I didn't look that deeply into it). Because the actual sent/received sequence numbers no longer match the sequence numbers stored in `p.awaitingSequences`, the received traffic starts to be counted as duplicate packets rather than received packets.

This was discussed previously on the go-ping repo: go-ping/ping#142
Changing the underlying type to `uint16` should also fix the problem, but just adding wrapping logic here seemed like the easiest approach.

It's also worth noting that go-ping (and the still-maintained pro-bing fork) eventually switched to using UUIDs to track packets. That would work too, but, as prometheus-community/pro-bing#112 points out, pro-bing technically has a memory leak because it never cleans those up.

I used this code to confirm the problem, and test my code after implementing this fix. It pings localhost every millisecond, so it reaches 65535 sent packets in under 2 minutes.
```go
package main

import (
	"log"
	"time"

	"github.com/geberl/go-ping-vrf"
)

func main() {
	p, err := ping.NewPinger("127.0.0.1")
	if err != nil {
		log.Fatal(err)
	}

	p.Interval = 1 * time.Millisecond
	p.SetPrivileged(true)

	go func() {
		ticker := time.NewTicker(5 * time.Second)
		for range ticker.C {
			stats := p.Statistics()
			log.Printf("sent %d rcvd %d dup %d\n", stats.PacketsSent, stats.PacketsRecv, stats.PacketsRecvDuplicates)
		}
	}()

	p.Run()
}
```